### PR TITLE
Bump yoga-sql-types to 0.2 and heterogeneous to 0.7

### DIFF
--- a/spago.lock
+++ b/spago.lock
@@ -33,7 +33,7 @@
               "foreign": ">=7.0.0 <8.0.0"
             },
             {
-              "heterogeneous": ">=0.6.0 <0.7.0"
+              "heterogeneous": ">=0.7.0 <0.8.0"
             },
             {
               "integers": ">=6.0.0 <7.0.0"
@@ -90,10 +90,10 @@
               "uuid": ">=9.0.0 <10.0.0"
             },
             {
-              "yoga-json": ">=5.2.0 <6.0.0"
+              "yoga-json": ">=5.2.1 <6.0.0"
             },
             {
-              "yoga-sql-types": ">=0.1.0 <0.2.0"
+              "yoga-sql-types": ">=0.2.0 <0.3.0"
             }
           ]
         },
@@ -475,8 +475,8 @@
     },
     "heterogeneous": {
       "type": "registry",
-      "version": "0.6.0",
-      "integrity": "sha256-nQgk2iHYe5LIi6ZzREgWaCU3y8oCwdhDSukT6xVMWdk=",
+      "version": "0.7.0",
+      "integrity": "sha256-pQwcFvhWL8noktxaoD7FlLs2F2lYf3QHoyO0VOWO3I0=",
       "dependencies": [
         "either",
         "foldable-traversable",
@@ -983,8 +983,8 @@
     },
     "yoga-json": {
       "type": "registry",
-      "version": "5.2.0",
-      "integrity": "sha256-M+kkz6E1Gf+C4bKnhqoBFIoVcc74loi3rLULePbB204=",
+      "version": "5.2.1",
+      "integrity": "sha256-12I7qIf27oKV/D/YRcHtGpN8n7GQ0Bm3uzvI4ZjOQrs=",
       "dependencies": [
         "arrays",
         "bifunctors",
@@ -1022,8 +1022,8 @@
     },
     "yoga-sql-types": {
       "type": "registry",
-      "version": "0.1.0",
-      "integrity": "sha256-vxOgnj3HK8F5gRHCNkIPNirORQtCBEKozG+CnrHtB84=",
+      "version": "0.2.0",
+      "integrity": "sha256-/fiSiEmSQ8UH2N7vp/E02Eo+Krbs6iGcre9haDV34Q8=",
       "dependencies": [
         "arrays",
         "bifunctors",
@@ -1051,8 +1051,8 @@
     },
     "yoga-test-docker": {
       "type": "registry",
-      "version": "0.1.1",
-      "integrity": "sha256-BKyHoGahs1D5PbjqSKL+6vvUJQ62mbpXYJOF9UwaGb8=",
+      "version": "0.1.2",
+      "integrity": "sha256-J/jgHvvwb04ZOhicRGucmrQhaokrYTc9XJ2dutsktq8=",
       "dependencies": [
         "aff",
         "datetime",

--- a/spago.yaml
+++ b/spago.yaml
@@ -18,7 +18,7 @@ package:
     - exceptions: ">=6.1.0 <7.0.0"
     - foldable-traversable: ">=6.0.0 <7.0.0"
     - foreign: ">=7.0.0 <8.0.0"
-    - heterogeneous: ">=0.6.0 <0.7.0"
+    - heterogeneous: ">=0.7.0 <0.8.0"
     - integers: ">=6.0.0 <7.0.0"
     - js-bigints: ">=2.2.1 <3.0.0"
     - js-date: ">=8.0.0 <9.0.0"
@@ -37,8 +37,8 @@ package:
     - typelevel-prelude: ">=7.0.0 <8.0.0"
     - unsafe-coerce: ">=6.0.0 <7.0.0"
     - uuid: ">=9.0.0 <10.0.0"
-    - yoga-json: ">=5.2.0 <6.0.0"
-    - yoga-sql-types: ">=0.1.0 <0.2.0"
+    - yoga-json: ">=5.2.1 <6.0.0"
+    - yoga-sql-types: ">=0.2.0 <0.3.0"
   test:
     main: Test.Postgres.Main
     dependencies:

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -4,6 +4,7 @@ import Prelude
 
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
+import Data.Time.Duration (Milliseconds(..))
 import Effect (Effect)
 import Effect.Aff (Aff, bracket, launchAff_, throwError, try)
 import Effect.Class (liftEffect)
@@ -433,11 +434,11 @@ main = launchAff_ do
   bracket
     ( do
         liftEffect $ log "Starting Postgres and waiting for it to be ready..."
-        Docker.startService "docker-compose.test.yml" 30
+        Docker.startService (Docker.ComposeFile "docker-compose.test.yml") (Docker.Timeout (Milliseconds 30000.0))
         liftEffect $ log "Postgres is ready!\n"
     )
     ( \_ -> do
-        Docker.stopService "docker-compose.test.yml"
+        Docker.stopService (Docker.ComposeFile "docker-compose.test.yml")
         liftEffect $ log "Cleanup complete\n"
     )
     (\_ -> runSpec [ consoleReporter ] spec)


### PR DESCRIPTION
## What

Forward-ports two dependency bounds:

- `heterogeneous` `>=0.6.0 <0.7.0` → `>=0.7.0 <0.8.0`
- `yoga-sql-types` `>=0.1.0 <0.2.0` → `>=0.2.0 <0.3.0`

## Why

yoga-postgres 0.3.0 still pins the old `yoga-sql-types` 0.1 / `heterogeneous` 0.6 line, so it can't co-install with current package sets that ship `yoga-sql-types` 0.2 / `heterogeneous` 0.7.

## Why it's safe

The library's entire surface on these two packages is unchanged across the bump, so no source changes are needed:

- **heterogeneous** — the only use is `class HFoldlWithIndex` (in `TypedQuery.purs`). `Heterogeneous.Folding` is byte-identical between 0.6.0 and 0.7.0; the only change in 0.7 is an additive `Heterogeneous.Variadic` module.
- **yoga-sql-types** — the only import is `Yoga.SQL.PostgresTypes (class ToSQLParam, SQLParameter, SQLQuery, TurnIntoSQLParam, argsFor, sqlQueryToString)`, and both `Yoga.SQL.Types` and `Yoga.SQL.PostgresTypes` are byte-identical between 0.1.0 and 0.2.0.

## Test note

Regenerating the lock also pulled `yoga-test-docker` 0.1.2, which newtyped `ComposeFile`/`Timeout`. I updated the two integration-test call sites in `test/Main.purs` to match (the 30s startup wait is now `Timeout (Milliseconds 30000.0)`). `spago build` is green for both the library and the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
